### PR TITLE
Fixed Scroll-to-Top Button Overlap with Chatbox

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -149,7 +149,7 @@ const Footer = () => {
       {/* Enhanced Scroll to Top Button */}
       <button
         onClick={scrollToTop}
-        className={`fixed bottom-6 right-6 p-3 rounded-full bg-blue-500 text-white shadow-lg hover:bg-blue-600 transition-all duration-300 transform hover:scale-110 ${
+        className={`fixed bottom-[80px] right-[29px] p-3 rounded-full bg-blue-500 text-white shadow-lg hover:bg-blue-600 transition-all duration-300 transform hover:scale-110 ${
           isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
         }`}
         aria-label="Scroll to top"


### PR DESCRIPTION
### **Description:**
Resolved the issue where the "Scroll-to-Top" button was overlapping with the chatbox in the footer. Adjusted the button's position by increasing the `bottom` and `right` properties in the CSS. The button is now placed higher and further to the right, ensuring proper spacing and improved accessibility. This update enhances the user interface and ensures no elements obstruct critical functionality.  

**Preview**
---
![Screenshot 2025-01-13 134853](https://github.com/user-attachments/assets/75ed3903-874c-40da-a2c6-8a5cdbd9392a)
---