### PR TITLE
Fixed: Text content of posts not Toggling to Theme #383

### DIFF
--- a/src/components/MarkdownDisplay.jsx
+++ b/src/components/MarkdownDisplay.jsx
@@ -20,6 +20,7 @@ export default function MarkdownDisplay({ content }) {
                         whiteSpace: 'pre-wrap',
                     }} />) : (
                         <MDEditor.Markdown source={content} style={{
+                            color: 'rgb(209, 213, 219)', // text-gray-300
                             marginLeft: 'auto', // mx-auto
                             marginRight: 'auto', // mx-auto
                             width: '100%', // w-full


### PR DESCRIPTION
Issue: #383 

✅ Problem
In dark mode, the Markdown content had a correctly toggled background color, but the text color remained dark, resulting in poor readability.

🎯 Solution
Added a color property to the style prop of <MDEditor.Markdown />.
Text color now toggles based on darkMode:
color: darkMode ? '#e2e8f0' : 'rgb(21, 21, 21)'

💻 Changes Made
Modified MarkdownDisplay.jsx:
Applied conditional text color to match the active theme (light/dark).

Thanks for reviewing my PR request.