### PR TITLE
fixed email verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2041,7 +2041,6 @@
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2256,7 +2255,8 @@
     "node_modules/appwrite": {
       "version": "16.1.0",
       "resolved": "https://registry.npmjs.org/appwrite/-/appwrite-16.1.0.tgz",
-      "integrity": "sha512-fFkhpOjxvobKKWdgvG3fcsYt93QEk0VJ86q7ALD53eWAFiFmpklNXeE4rpXqdmtWpin4VuyWhkmH1aOF/QxvsA=="
+      "integrity": "sha512-fFkhpOjxvobKKWdgvG3fcsYt93QEk0VJ86q7ALD53eWAFiFmpklNXeE4rpXqdmtWpin4VuyWhkmH1aOF/QxvsA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/arg": {
       "version": "5.0.2",

--- a/src/appwrite/auth.js
+++ b/src/appwrite/auth.js
@@ -18,41 +18,42 @@ export class AuthService {
     }
 
     async createAccount({ email, password, name }) {
-        try {
-            const userAccount = await this.account.create(ID.unique(), email, password, name);
-            console.log("User Account Created:", userAccount);
+    try {
+        const userAccount = await this.account.create(ID.unique(), email, password, name);
+        console.log("User Account Created:", userAccount);
 
-            const session = await this.account.createEmailPasswordSession(email, password);
-            console.log("Temporary Session Created:", session);
+        // ⚠️ Step 1: Create a session *BEFORE* sending verification
+        const session = await this.account.createEmailPasswordSession(email, password);
+        console.log("Temporary Session Created:", session);
 
-            // ✅ Save user info in DB (new `users` collection)
-            await this.databases.createDocument(
-                conf.appwriteDatabaseId,
-                conf.appwriteUserCollectionId,
-                ID.unique(),
-                {
-                    userId: userAccount.$id,
-                    name,
-                    email,
-                    createdAt: new Date().toISOString()
-                }
-            );
+        // Step 2: Send verification email (now session is active)
+        await this.account.createVerification(`${baseLink}/verify-email`);
 
-            await this.account.createVerification(`${baseLink}/verify-email`);
-            // Optionally log user out after sending email
-            await this.account.deleteSessions();
-
-            return userAccount;
-        } catch (error) {
-            console.error("Error during account creation:", error);
-            try {
-                await this.account.deleteSessions();
-            } catch (sessionError) {
-                console.error("Error cleaning up session:", sessionError);
+        // Step 3: Store user in DB (optional, but safe to do after session)
+        await this.databases.createDocument(
+            conf.appwriteDatabaseId,
+            conf.appwriteCollectionId,
+            ID.unique(),
+            {
+                userId: userAccount.$id,
+                name: name,
             }
-            throw error;
+        );
+
+        // Step 4: Clean up session
+        await this.account.deleteSessions();
+
+        return userAccount;
+    } catch (error) {
+        console.error("Error during account creation:", error);
+        try {
+            await this.account.deleteSessions();
+        } catch (sessionError) {
+            console.log("Error cleaning up session:", sessionError);
         }
+        throw error;
     }
+}
 
     async login({ email, password }) {
         try {


### PR DESCRIPTION
This update fixes a bug in the signup process where users were not receiving email verification links after creating an account.

 Changes Made:
update createAccount() in auth.js
Moved createVerification() before database document creation
Ensured createEmailPasswordSession() is called immediately after account creation, before verification

 Why This Fix Was Needed
Previously, the email verification step was called after creating the database record
If database creation failed, the email link was never sent — resulting in users being stuck in an unverified state
Appwrite requires the user to be authenticated (session active) before sending verification emails
Now, email is sent immediately after session creation.

