### PR TITLE
Fix: Replaced array with individual string queries in Query.search() to prevent type error

### DIFF
--- a/src/appwrite/config.js
+++ b/src/appwrite/config.js
@@ -100,7 +100,7 @@ export class Service {
                 conf.appwriteDatabaseId,
                 conf.appwriteCollectionId,
                 [
-                    Query.search("title", [key]),
+                    Query.search("title", key),
                     Query.equal("status", "active")
                 ]
             );


### PR DESCRIPTION
This PR fixes a type error caused by incorrect usage of the Query.search() method, where an array was passed as the second argument instead of a string.

Changes Made:
Replaced Query.search("field", ["value1", "value2"]) with separate Query.search() calls for each value.
src/appwrite/config.js

Ensured each Query.search() receives a valid string input.


 Error Fixed:
Query.search() expects the second argument to be a string, but an array is passed instead