### PR TITLE
Fix: Removed Unnecessary confirmPassword from Password Reset Flow

### DIFF
--- a/src/appwrite/auth.js
+++ b/src/appwrite/auth.js
@@ -219,7 +219,6 @@ export class AuthService {
                 userId,
                 secret,
                 newPassword,
-                confirmPassword
             );
         } catch (error) {
             console.error("Appwrite service :: completeReset :: error", error);

--- a/src/components/ResetPassword.jsx
+++ b/src/components/ResetPassword.jsx
@@ -23,7 +23,6 @@ function ResetPassword() {
                 userId,
                 secret,
                 data.password,
-                data.confirmPassword
             );
             
             if (session) {


### PR DESCRIPTION
###  Fix: Removed Unnecessary `confirmPassword` from Password Reset Flow

### Summary
In the `ResetPassword` component, the `confirmPassword` field (used only for frontend validation) was being unnecessarily passed to `authService.completeReset`, and then forwarded to `account.updateRecovery`, which does not accept it.

This PR:
- Removes `confirmPassword` from the function call and definition.
- Cleans up parameter usage to match Appwrite’s expected input.

---

###  GSSoC Contribution
This fix is part of my GSSoC contributions.  
Please assign this issue to me if valid and kindly add appropriate labels 

---

Let me know if any changes are needed. Happy to improve it further!
closes #505 
